### PR TITLE
Feature ETP-3903: add reactor initializer tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,10 +50,25 @@ repositories {
 
 sourceSets {
     main {
+        java {
+            srcDirs("src")
+        }
         resources {
             srcDirs("etendo-resources")
         }
     }
+    test {
+        java {
+            srcDirs("src-test/src")
+        }
+        resources {
+            srcDirs("src-test/resources")
+        }
+    }
+}
+
+def coreCompileClasspath = rootProject.configurations.compileClasspath.filter {
+    !it.path.contains('/modules/')
 }
 
 /**
@@ -61,8 +76,14 @@ sourceSets {
 * Ex: implementation "com.sun.mail:javax.mail:1.6.2"
 */
 dependencies {
+        compileOnly files(rootProject.sourceSets.main.output)
+        compileOnly files(coreCompileClasspath)
+        testImplementation files(rootProject.sourceSets.main.output)
+        testImplementation files(coreCompileClasspath)
+        testRuntimeOnly files(rootProject.sourceSets.main.output, coreCompileClasspath)
         testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
         testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+        testImplementation 'org.mockito:mockito-core:5.12.0'
 
         // https://mvnrepository.com/artifact/io.projectreactor.kafka/reactor-kafka
         implementation 'io.projectreactor.kafka:reactor-kafka:1.3.14'

--- a/build.gradle
+++ b/build.gradle
@@ -50,46 +50,18 @@ repositories {
 
 sourceSets {
     main {
-        java {
-            srcDirs("src")
-        }
         resources {
             srcDirs("etendo-resources")
         }
     }
-    test {
-        java {
-            srcDirs("src-test/src")
-        }
-        resources {
-            srcDirs("src-test/resources")
-        }
-    }
 }
-
-def coreCompileClasspath = rootProject.configurations.compileClasspath.filter {
-    !it.path.contains('/modules/')
-}
-
 /**
 * Declare Java dependencies using 'implementation'
 * Ex: implementation "com.sun.mail:javax.mail:1.6.2"
 */
 dependencies {
-        compileOnly files(rootProject.sourceSets.main.output)
-        compileOnly files(coreCompileClasspath)
-        testImplementation files(rootProject.sourceSets.main.output)
-        testImplementation files(coreCompileClasspath)
-        testRuntimeOnly files(rootProject.sourceSets.main.output, coreCompileClasspath)
-        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
-        testImplementation 'org.mockito:mockito-core:5.12.0'
-
-        // https://mvnrepository.com/artifact/io.projectreactor.kafka/reactor-kafka
-        implementation 'io.projectreactor.kafka:reactor-kafka:1.3.14'
-
-        implementation('com.etendoerp.platform:etendo-core:[26.1.0,26.2.0)')
-
+    //implementation 'io.projectreactor.kafka:reactor-kafka:1.3.14'
+    implementation('com.etendoerp.platform:etendo-core:[26.1.0,26.2.0)')
 }
 
 test {

--- a/src-test/src/com/etendoerp/reactor/EtendoReactorInitializerTest.java
+++ b/src-test/src/com/etendoerp/reactor/EtendoReactorInitializerTest.java
@@ -7,14 +7,12 @@ import static org.mockito.Mockito.verify;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
-import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Stream;
 
-import jakarta.enterprise.inject.Instance;
-import jakarta.enterprise.util.TypeLiteral;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.util.TypeLiteral;
 
 import org.junit.jupiter.api.Test;
 
@@ -87,15 +85,6 @@ class EtendoReactorInitializerTest {
         return values.get(0);
       }
 
-      @Override
-      public Handle<EtendoReactorSetup> getHandle() {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public Iterable<? extends Handle<EtendoReactorSetup>> handles() {
-        throw new UnsupportedOperationException();
-      }
     };
   }
 

--- a/src-test/src/com/etendoerp/reactor/EtendoReactorInitializerTest.java
+++ b/src-test/src/com/etendoerp/reactor/EtendoReactorInitializerTest.java
@@ -1,0 +1,108 @@
+package com.etendoerp.reactor;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.util.TypeLiteral;
+
+import org.junit.jupiter.api.Test;
+
+class EtendoReactorInitializerTest {
+
+  @Test
+  void initializeShouldInvokeInitOnEverySetup() throws Exception {
+    EtendoReactorSetup first = mock(EtendoReactorSetup.class);
+    EtendoReactorSetup second = mock(EtendoReactorSetup.class);
+    EtendoReactorInitializer initializer = new EtendoReactorInitializer();
+
+    setSetups(initializer, instanceOf(first, second));
+
+    initializer.initialize();
+
+    verify(first, times(1)).init();
+    verify(second, times(1)).init();
+  }
+
+  @Test
+  void initializeShouldDoNothingWhenNoSetupsAreAvailable() throws Exception {
+    EtendoReactorInitializer initializer = new EtendoReactorInitializer();
+
+    setSetups(initializer, instanceOf());
+
+    assertDoesNotThrow(initializer::initialize);
+  }
+
+  private Instance<EtendoReactorSetup> instanceOf(EtendoReactorSetup... setups) {
+    List<EtendoReactorSetup> values = Arrays.asList(setups);
+    return new Instance<>() {
+      @Override
+      public Instance<EtendoReactorSetup> select(Annotation... qualifiers) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public <U extends EtendoReactorSetup> Instance<U> select(Class<U> subtype,
+          Annotation... qualifiers) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public <U extends EtendoReactorSetup> Instance<U> select(TypeLiteral<U> subtype,
+          Annotation... qualifiers) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public boolean isUnsatisfied() {
+        return values.isEmpty();
+      }
+
+      @Override
+      public boolean isAmbiguous() {
+        return false;
+      }
+
+      @Override
+      public void destroy(EtendoReactorSetup instance) {
+      }
+
+      @Override
+      public Iterator<EtendoReactorSetup> iterator() {
+        return values.iterator();
+      }
+
+      @Override
+      public EtendoReactorSetup get() {
+        return values.get(0);
+      }
+
+      @Override
+      public Handle<EtendoReactorSetup> getHandle() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Iterable<? extends Handle<EtendoReactorSetup>> handles() {
+        throw new UnsupportedOperationException();
+      }
+    };
+  }
+
+  private void setSetups(EtendoReactorInitializer initializer, Instance<EtendoReactorSetup> setups)
+      throws Exception {
+    Field field = EtendoReactorInitializer.class.getDeclaredField("setups");
+    field.setAccessible(true);
+    field.set(initializer, setups);
+  }
+}

--- a/src-test/src/com/etendoerp/reactor/EtendoReactorInitializerTest.java
+++ b/src-test/src/com/etendoerp/reactor/EtendoReactorInitializerTest.java
@@ -1,3 +1,19 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance
+ * with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright (C) 2022-2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
 package com.etendoerp.reactor;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/src-test/src/com/etendoerp/reactor/EtendoReactorInitializerTest.java
+++ b/src-test/src/com/etendoerp/reactor/EtendoReactorInitializerTest.java
@@ -18,6 +18,15 @@ import org.junit.jupiter.api.Test;
 
 class EtendoReactorInitializerTest {
 
+  /** Dedicated unchecked exception for reflective test setup failures. */
+  private static final class TestReflectionException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    private TestReflectionException(String message, ReflectiveOperationException cause) {
+      super(message, cause);
+    }
+  }
+
   @Test
   void initializeShouldInvokeInitOnEverySetup() throws Exception {
     EtendoReactorSetup first = mock(EtendoReactorSetup.class);
@@ -73,6 +82,7 @@ class EtendoReactorInitializerTest {
 
       @Override
       public void destroy(EtendoReactorSetup instance) {
+        // No cleanup is required because this test instance never creates CDI-managed beans.
       }
 
       @Override
@@ -88,10 +98,13 @@ class EtendoReactorInitializerTest {
     };
   }
 
-  private void setSetups(EtendoReactorInitializer initializer, Instance<EtendoReactorSetup> setups)
-      throws Exception {
-    Field field = EtendoReactorInitializer.class.getDeclaredField("setups");
-    field.setAccessible(true);
-    field.set(initializer, setups);
+  private void setSetups(EtendoReactorInitializer initializer, Instance<EtendoReactorSetup> setups) {
+    try {
+      Field field = EtendoReactorInitializer.class.getDeclaredField("setups");
+      field.setAccessible(true);
+      field.set(initializer, setups);
+    } catch (ReflectiveOperationException exception) {
+      throw new TestReflectionException("Unable to inject test setups", exception);
+    }
   }
 }


### PR DESCRIPTION
This pull request adds new unit tests for the `EtendoReactorInitializer` class to ensure its initialization logic is working as expected. The tests use Mockito to verify that all registered setups are initialized and that the initializer handles the absence of setups gracefully.

**Testing improvements:**

* Added `EtendoReactorInitializerTest` with tests to verify that `initialize()` calls `init()` on every `EtendoReactorSetup` and does nothing when no setups are present.
* Implemented helper methods to inject mock `Instance<EtendoReactorSetup>` objects for testing purposes.